### PR TITLE
Simplify template to use latest node-lambda, run locally and deploy easily.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
-.c9
-.idea
+.env

--- a/README.md
+++ b/README.md
@@ -1,48 +1,35 @@
-# phantom-lambda-template
+# PhantomJS Lambda Template
 
-The bare minimum for a [phantomjs](http://phantomjs.org/)app running on [Amazon Lambda](http://aws.amazon.com/lambda/).
-Based off of [node-lambda-template](https://github.com/rebelmail/node-lambda-template)
+A [PhantomJS](http://phantomjs.org/) node.js app for [Amazon Lambda](http://aws.amazon.com/lambda/). Based on [node-lambda-template](https://github.com/rebelmail/node-lambda-template) using [node-lambda](https://github.com/rebelmail/node-lambda). The app includes a PhantomJS binary (`phantomjs`) compiled for AWS Linux (https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-x86_64.tar.bz2).
 
-* Keep in mind that aws-lambda runs on Aws Linux, you will have to make sure your package is compiled for Aws-Linux
+> **Note:** Since there was [an issue](https://github.com/rebelmail/node-lambda/issues/19) with the deployment script this template uses a [node-lambda fork](https://github.com/christianklotz/node-lambda) until the [pull request](https://github.com/rebelmail/node-lambda/pull/20) has been accepted or an alternative solution has been found.
 
-The phantomjs program has been build to for Linux, https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-x86_64.tar.bz2
-If you are going to run this locally you will have to swap out phantomjs with the assembly built for your OS.
 
-It uses [node-lambda](https://github.com/rebelmail/node-lambda) under the hood to locally run and also deploy your node.js Amazon Lambda application.
+## Setup
 
-```
-./node_modules/.bin/node-lambda run
+Install dependencies using npm. It'll install the AWS SDK as well as PhantomJS on the development machine.
+
+```shell
+npm install
 ```
 
 ## Usage
 
-There are 3 available commands, make sure to use the appropriate phantomjs for your OS. 
-
-```
-./node_modules/.bin/node-lambda setup
-./node_modules/.bin/node-lambda run
-./node_modules/.bin/node-lambda deploy
+To run the function locally execute the following command.
+```shell
+npm run start
 ```
 
-## Install
+Run the setup command to generate the environment file with the configuration used for the Amazon Lambda function. Edit the resulting `.env.` file with your custom settings.
 
-```
-git clone https://github.com/justengland/phantom-lambda-template.git
-cd node-lambda-template
-npm install
+```shell
+npm run setup
 ```
 
-## Package
-zip -r phantom.zip . --exclude=*.DS_Store* --exclude=*.git* --exclude=*node_modules* --exclude=*.idea* --exclude=*.c9*
+Run the following command to deploy the app to Amazon Lambda. Providing the environment param is optional. If provided the function deployed to Amazon Lambda will use the environment as a prefix in the function name, e.g. FunctionName-production-version.
 
+```shell
+npm run deploy -- --environment {environment}
+```
 
-## Install Phantomjs
-npm install phantomjs --phantomjs_cdnurl=http://cnpmjs.org/downloads
-
-
-## Ideas
-1. install phantom locally using NPM - this will install the phantomjs version for your OS into node_modules
-2. Package for Lambda without the node_modules, then the node script will read from the disk, 
-    if node_modules does not exists then read it from the root of the package which will be setup for lambda
-
-
+> **Note:** npm version 2.x or newer required to pass arguments to the scripts using `-- args`

--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 A [PhantomJS](http://phantomjs.org/) node.js app for [Amazon Lambda](http://aws.amazon.com/lambda/). Based on [node-lambda-template](https://github.com/rebelmail/node-lambda-template) using [node-lambda](https://github.com/rebelmail/node-lambda). The app includes a PhantomJS binary (`phantomjs`) compiled for AWS Linux (https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-x86_64.tar.bz2).
 
-> **Note:** Since there was [an issue](https://github.com/rebelmail/node-lambda/issues/19) with the deployment script this template uses a [node-lambda fork](https://github.com/christianklotz/node-lambda) until the [pull request](https://github.com/rebelmail/node-lambda/pull/20) has been accepted or an alternative solution has been found.
-
-
 ## Setup
 
 Install dependencies using npm. It'll install the AWS SDK as well as PhantomJS on the development machine.
@@ -15,21 +12,21 @@ npm install
 
 ## Usage
 
+After installing use the following `npm` commands as described below. They're only wrapping the `node-lambda` functionality to allow `node-lambda` to be installed only locally. Additional params can be provided using `-- args`. For a list of available options see the `node-lambda` [documentation](https://github.com/RebelMail/node-lambda).
+
+Run the setup command to generate the environment file with the configuration used for the Amazon Lambda function. Edit the resulting `.env.` file with your custom settings.
+```shell
+npm run setup
+```
+
 To run the function locally execute the following command.
 ```shell
 npm run start
 ```
 
-Run the setup command to generate the environment file with the configuration used for the Amazon Lambda function. Edit the resulting `.env.` file with your custom settings.
-
+Run the following command to deploy the app to Amazon Lambda. 
 ```shell
-npm run setup
-```
-
-Run the following command to deploy the app to Amazon Lambda. Providing the environment param is optional. If provided the function deployed to Amazon Lambda will use the environment as a prefix in the function name, e.g. FunctionName-production-version.
-
-```shell
-npm run deploy -- --environment {environment}
+npm run deploy
 ```
 
 > **Note:** npm version 2.x or newer required to pass arguments to the scripts using `-- args`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phantom-lambda-template",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "The bare minimum for a phantomjs app running on Amazon Lambda.",
   "main": "index.js",
   "repository": {
@@ -13,12 +13,16 @@
     "url": "https://github.com/rebelmail/node-lambda-template/issues"
   },
   "homepage": "https://github.com/rebelmail/node-lambda-template",
-  "dependencies": {
-    "node-lambda": "0.1.5"
+  "dependencies": {},
+  "devDependencies": {
+    "aws-sdk": "^2.1.39",
+    "node-lambda": "git+https://github.com/christianklotz/node-lambda.git",
+    "phantomjs": "^1.9.17"
   },
-  "devDependencies": {},
   "scripts": {
-    "run": "node run"
+    "setup": "node-lambda setup",
+    "start": "node-lambda run",
+    "deploy": "node-lambda deploy"
   },
   "keywords": [
     "phantomjs",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {},
   "devDependencies": {
     "aws-sdk": "^2.1.39",
-    "node-lambda": "git+https://github.com/christianklotz/node-lambda.git",
+    "node-lambda": "^0.6.1",
     "phantomjs": "^1.9.17"
   },
   "scripts": {

--- a/package.sh
+++ b/package.sh
@@ -1,2 +1,0 @@
-rm -f phantom.zip
-zip -r phantom.zip . --exclude=*.DS_Store* --exclude=*.git* --exclude=*node_modules* --exclude=*.idea* --exclude=*.c9*

--- a/run.js
+++ b/run.js
@@ -1,6 +1,0 @@
-console.log('-------------------------------------------------------------------------');
-    console.log('   phantom-lambda Started');
-require('./index').handler(null, { done: function() {
-    console.log('   phantom-lambda Completed');
-    console.log('-------------------------------------------------------------------------');
-}});


### PR DESCRIPTION
The use of the custom zip command in `package.sh` is now redundant since `node-lambda` got updated. Previously there was [an issue](https://github.com/rebelmail/node-lambda/issues/19) with the deployment script ignoring file permissions which resulting in binaries not being executable. This has been fixed with [this pull request](https://github.com/rebelmail/node-lambda/pull/20).

I also made `phantomjs` a development dependency so it automatically installs it correctly for the development platform as part of `npm install`. For the deployment it's bundling the binary built for AWS Linux as it has done in the past. As a result the `run.js` script is now also redundant since we can simply rely on the `node-lambda run` command.

All changes are reflected in the updated README, too.
