### PR TITLE
Amazon Linux build

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ npm run deploy
 ```
 
 > **Note:** npm version 2.x or newer required to pass arguments to the scripts using `-- args`
+
+## Building phantomjs
+
+If you want to use a different version of phantomjs or have trouble with the included version, follow the instructions in [build-phantomjs.sh](build-phantomjs.sh).

--- a/build-phantomjs.sh
+++ b/build-phantomjs.sh
@@ -1,0 +1,26 @@
+# Launch an EC2 instance using the region-appropriate AMI from this document:
+# http://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.
+
+# Use a fairly beefy Spot Instance (c4.large is good) unless you want to wait
+# for a long time. Don't bother with a t2.micro.
+
+# Once it starts, SSH into the machine:
+
+ssh ec2-user@your-ec2-box.amazonaws.com
+
+# And then run (following the instructions from
+# http://phantomjs.org/build.html):
+
+sudo yum -y install gcc gcc-c++ make flex bison gperf ruby \
+  openssl-devel freetype-devel fontconfig-devel libicu-devel sqlite-devel \
+  libpng-devel libjpeg-devel
+
+wget https://github.com/ariya/phantomjs/archive/1.9.7.zip
+unzip 1.9.7.zip
+cd phantomjs-1.9.7/
+./build.sh --confirm
+
+# Once it's finished, retrieve the build product (run from your local machine):
+scp ec2-user@your-ec2-box.amazonaws.com:phantomjs-1.9.7/bin/phantomjs .
+
+# That's it! Don't forget to terminate the EC2 instance.


### PR DESCRIPTION
Hi! Thanks for putting this together, it saved me a lot of time.

I did have some trouble with the included `phantomjs` binary—I got this error when I ran `npm run deploy` from a fresh clone (after setting up a `.env`):

```
2015-11-18T00:50:10.731Z    521db901-8d8e-11e5-b9df-cd31cc90ece2    Calling phantom:  /var/task/phantomjs [ '/var/task/phantomjs-script.js' ]
2015-11-18T00:50:10.809Z    521db901-8d8e-11e5-b9df-cd31cc90ece2    child process exited with code 127
```

I enabled `LD_DEBUG` and got:

```
 7: 
 7: file=libicudata.so.50 [0];  needed by /var/task/phantomjs [0]
 7: find library=libicudata.so.50 [0]; searching
 7:  search cache=/etc/ld.so.cache
 7:  search path=/lib64/tls/x86_64:/lib64/tls:/lib64/x86_64:/lib64:/usr/lib64/tls/x86_64:/usr/lib64/tls:/usr/lib64/x86_64:/usr/lib64        (system search path)
 7:   trying file=/lib64/tls/x86_64/libicudata.so.50
 7:   trying file=/lib64/tls/libicudata.so.50
 7:   trying file=/lib64/x86_64/libicudata.so.50
 7:   trying file=/lib64/libicudata.so.50
 7:   trying file=/usr/lib64/tls/x86_64/libicudata.so.50
 7:   trying file=/usr/lib64/tls/libicudata.so.50
 7:   trying file=/usr/lib64/x86_64/libicudata.so.50
 7:   trying file=/usr/lib64/libicudata.so.50
 7: 
/var/task/phantomjs: error while loading shared libraries: libicudata.so.50: cannot open shared object file: No such file or directory
```

Presumably this is related to https://github.com/ariya/phantomjs/issues/12948.

I rebuilt `phantomjs` on the most recent version of Amazon Linux (ami-1ecae776), tried again, and it worked.

I suspect Amazon updated the Lambda environment and this broke the included binary.

This PR updates the included `phantomjs` binary (compiled from Phantom.js 1.9.7) and includes instructions for making new ones.

If you create a new Lambda function using this repo (probably necessary to get the newest Lambda environment), does the previous binary run for you?
